### PR TITLE
Improve exporter

### DIFF
--- a/src/qgis_server_light/interface/qgis.py
+++ b/src/qgis_server_light/interface/qgis.py
@@ -196,12 +196,15 @@ class PostgresSource(Source):
     schema: str = field(
         metadata={"name": "Schema", "type": "Element", "required": True}
     )
-    srid: str = field(metadata={"name": "Srid", "type": "Element", "required": True})
     table: str = field(metadata={"name": "Table", "type": "Element", "required": True})
     type: str = field(metadata={"name": "Type", "type": "Element", "required": True})
     username: str = field(
         metadata={"name": "Username", "type": "Element", "required": True}
     )
+    srid: str = field(
+        default=None, metadata={"name": "Srid", "type": "Element", "required": True}
+    )
+    sslmode: str = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
When exporting information about postgres datasources in some cases export failed because information was missing in the data connection string. This PR makes the extraction of information more robust.