### PR TITLE
Extract more dataset field properties

### DIFF
--- a/src/qgis_server_light/exporter/extract.py
+++ b/src/qgis_server_light/exporter/extract.py
@@ -137,6 +137,22 @@ def obtain_nullable(field: QgsField):
     return False
 
 
+def provide_field_length(field: QgsField) -> int | None:
+    length = field.length()
+    if length >= 0:
+        return length
+    else:
+        return None
+
+
+def provide_field_precision(field: QgsField) -> int | None:
+    precision = field.precision()
+    if precision >= 0:
+        return precision
+    else:
+        return None
+
+
 def extract_fields(
     layer: QgsVectorLayer, types_from_editor_widget: bool = False
 ) -> List[Field]:
@@ -156,6 +172,8 @@ def extract_fields(
                 alias=field.alias() or field.name().title(),
                 comment=field.comment(),
                 nullable=(field_index not in pk_indexes) and obtain_nullable(field),
+                length=provide_field_length(field),
+                precision=provide_field_precision(field),
             )
         )
     return fields

--- a/src/qgis_server_light/exporter/extract.py
+++ b/src/qgis_server_light/exporter/extract.py
@@ -153,6 +153,7 @@ def extract_fields(
                 type=field.typeName(),
                 type_simple=attribute_type,
                 alias=field.alias() or field.name().title(),
+                comment=field.comment(),
                 nullable=(field_index not in pk_indexes) and obtain_nullable(field),
             )
         )

--- a/src/qgis_server_light/exporter/extract.py
+++ b/src/qgis_server_light/exporter/extract.py
@@ -1,6 +1,4 @@
 import json
-import os
-import uuid
 import re
 import unicodedata
 import zlib
@@ -53,7 +51,7 @@ from qgis_server_light.interface.qgis import WmsSource
 from qgis_server_light.interface.qgis import WmtsSource
 
 
-def obtain_simple_types(field: QgsField) -> str:
+def obtain_simple_types_xml(field: QgsField) -> str:
     """
 
     Args:
@@ -88,6 +86,42 @@ def obtain_simple_types(field: QgsField) -> str:
         return "dateTime"
     else:
         return "string"
+
+
+def obtain_simple_types_json(field: QgsField) -> Tuple[str, str] | Tuple[str, None]:
+    """
+
+    Args:
+        field: The field of an `QgsVectorLayer`.
+
+    Returns:
+        Unified type name regarding
+        [XSD spec](https://www.w3.org/TR/xmlschema11-2/#built-in-primitive-datatypes)
+        IMPORTANT: If type is not matched within the function it will be `string` always!
+    """
+    attribute_type = field.type()
+    if attribute_type == QMetaType.Type.Int:
+        return "integer", None
+    elif attribute_type == QMetaType.Type.UInt:
+        return "integer", "uint32"
+    elif attribute_type == QMetaType.Type.LongLong:
+        return "integer", "int64"
+    elif attribute_type == QMetaType.Type.ULongLong:
+        return "integer", "uint64"
+    elif attribute_type == QMetaType.Type.Double:
+        return "number", "double"
+    elif attribute_type == QMetaType.Type.Float:
+        return "number", "float"
+    elif attribute_type == QMetaType.Type.Bool:
+        return "boolean", None
+    elif attribute_type == QMetaType.Type.QDate:
+        return "string", "date"
+    elif attribute_type == QMetaType.Type.QTime:
+        return "string", "time"
+    elif attribute_type == QMetaType.Type.QDateTime:
+        return "string", "date-time"
+    else:
+        return "string", None
 
 
 def obtain_simple_types_from_editor_widget(field: QgsField) -> str | None:
@@ -139,7 +173,7 @@ def obtain_nullable(field: QgsField):
 
 def provide_field_length(field: QgsField) -> int | None:
     length = field.length()
-    if length >= 0:
+    if length > 0:
         return length
     else:
         return None
@@ -147,7 +181,7 @@ def provide_field_length(field: QgsField) -> int | None:
 
 def provide_field_precision(field: QgsField) -> int | None:
     precision = field.precision()
-    if precision >= 0:
+    if precision > 0:
         return precision
     else:
         return None
@@ -159,16 +193,22 @@ def extract_fields(
     fields = []
     pk_indexes = layer.dataProvider().pkAttributeIndexes()
     for field_index, field in enumerate(layer.fields()):
-        attribute_type = obtain_simple_types(field)
+        attribute_type_xml = obtain_simple_types_xml(field)
         if types_from_editor_widget:
             editor_widget_type = obtain_simple_types_from_editor_widget(field)
             if editor_widget_type:
-                attribute_type = editor_widget_type
+                attribute_type_xml = editor_widget_type
+        attribute_type_json, attribute_type_json_format = obtain_simple_types_json(
+            field
+        )
         fields.append(
             Field(
+                is_primary_key=(field_index in pk_indexes),
                 name=field.name(),
                 type=field.typeName(),
-                type_simple=attribute_type,
+                type_wfs=attribute_type_xml,
+                type_oapif=attribute_type_json,
+                type_oapif_format=attribute_type_json_format,
                 alias=field.alias() or field.name().title(),
                 comment=field.comment(),
                 nullable=(field_index not in pk_indexes) and obtain_nullable(field),

--- a/src/qgis_server_light/exporter/extract.py
+++ b/src/qgis_server_light/exporter/extract.py
@@ -134,6 +134,7 @@ def obtain_nullable(field: QgsField):
         == QgsFieldConstraints.Constraint.ConstraintNotNull
     ):
         return True
+    return False
 
 
 def extract_fields(

--- a/src/qgis_server_light/interface/qgis.py
+++ b/src/qgis_server_light/interface/qgis.py
@@ -121,8 +121,18 @@ class Field:
 
     name: str = field(metadata={"name": "Name", "type": "Element", "required": True})
     type: str = field(metadata={"name": "Type", "type": "Element", "required": True})
-    type_simple: Optional[str] = field(
-        default=None, metadata={"name": "SimpleType", "type": "Element"}
+    is_primary_key: bool = field(
+        default=False,
+        metadata={"name": "IsPrimaryKey", "type": "Element", "required": True},
+    )
+    type_wfs: Optional[str] = field(
+        default=None, metadata={"name": "TypeWfs", "type": "Element"}
+    )
+    type_oapif: Optional[str] = field(
+        default=None, metadata={"name": "TypeOapif", "type": "Element"}
+    )
+    type_oapif_format: Optional[str] = field(
+        default=None, metadata={"name": "TypeOapifFormat", "type": "Element"}
     )
     alias: Optional[str] = field(
         default=None, metadata={"name": "Alias", "type": "Element"}

--- a/src/qgis_server_light/interface/qgis.py
+++ b/src/qgis_server_light/interface/qgis.py
@@ -133,6 +133,12 @@ class Field:
     nullable: bool = field(
         default=True, metadata={"name": "Nullable", "type": "Element"}
     )
+    length: Optional[int] = field(
+        default=None, metadata={"name": "Length", "type": "Element"}
+    )
+    precision: Optional[int] = field(
+        default=None, metadata={"name": "Precision", "type": "Element"}
+    )
 
 
 @dataclass

--- a/src/qgis_server_light/interface/qgis.py
+++ b/src/qgis_server_light/interface/qgis.py
@@ -115,6 +115,7 @@ class Field:
         type_simple: Translated type for further usage. Based on the simple types of
             [XSD spec](https://www.w3.org/TR/xmlschema11-2/#built-in-primitive-datatypes).
         alias: Human readable name.
+        comment: Field description.
         nullable: If this field can be NULL or not.
     """
 
@@ -125,6 +126,9 @@ class Field:
     )
     alias: Optional[str] = field(
         default=None, metadata={"name": "Alias", "type": "Element"}
+    )
+    comment: Optional[str] = field(
+        default=None, metadata={"name": "Comment", "type": "Element"}
     )
     nullable: bool = field(
         default=True, metadata={"name": "Nullable", "type": "Element"}

--- a/src/qgis_server_light/interface/qgis.py
+++ b/src/qgis_server_light/interface/qgis.py
@@ -415,6 +415,12 @@ class Vector(DataSet):
         metadata={"name": "GeometryTypeWkb", "type": "Element"},
     )
 
+    def get_field_by_name(self, name: str) -> Field | None:
+        for field in self.fields:
+            if field.name == name:
+                return field
+        return None
+
 
 @dataclass
 class Custom(DataSet):


### PR DESCRIPTION
Extract more detailed dataset field properties from QGIS:
- is primary key (bool)
- field type for different use cases (wfs, oapif)
- comment
- string length
- precision 
