### PR TITLE
Improve dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ build
 dist
 docs
 Dockerfile
+.env


### PR DESCRIPTION
Avoid copying .env file into docker images to prevent unexpected configuration.