### PR TITLE
Ensure the username is transported correctly with pg_service.conf 

### DIFF
--- a/src/qgis_server_light/exporter/extract.py
+++ b/src/qgis_server_light/exporter/extract.py
@@ -659,11 +659,7 @@ class Exporter:
             # merging pg_service content with config of qgis project (qgis project config overwrites
             # pg_service configs
             config = Exporter.merge_dicts(service_config, datasource)
-        if config.get("username"):
-            config["username"]
-        elif config.get("user"):
-            config["user"]
-        else:
+        if not config.get("username") and not config.get("user"):
             raise LookupError(
                 f"Configuration does not contain any info about the db user name {config}"
             )
@@ -700,7 +696,12 @@ class Exporter:
             ):
                 result[key] = Exporter.merge_dicts(result[key], value)
             else:
-                result[key] = value
+                if key in ["user", "username"] and value is None:
+                    logging.debug(
+                        f"QGIS Datasource contained '{key}', but it's value was NONE, so we not copied that over! "
+                    )
+                else:
+                    result[key] = value
         return result
 
     @staticmethod

--- a/src/qgis_server_light/interface/exporter/extract.py
+++ b/src/qgis_server_light/interface/exporter/extract.py
@@ -375,7 +375,7 @@ class PostgresSource(Source):
             type=int(decoded_uri.get("type"))
             if decoded_uri.get("type") is not None
             else None,
-            username=decoded_uri.get("username"),
+            username=decoded_uri.get("username") or decoded_uri.get("user"),
             srid=decoded_uri.get("srid"),
             sslmode=int(decoded_uri.get("sslmode", 2)),
             service=decoded_uri.get("service"),


### PR DESCRIPTION
Fixes the situation where qgis project might deliver a None value for username in the datasource for postgres when a pg_service.conf delivers user. Previously the null value was overwriting the pg_service value.

In addition it makes sure in the resulting interface instance either user (from pg_service.conf) or username (from QGIS layer source) is used to transport the db users name. 