### PR TITLE
Fix export api on project names containing '.'

### DIFF
--- a/src/qgis_server_light/exporter/api.py
+++ b/src/qgis_server_light/exporter/api.py
@@ -16,10 +16,26 @@ allowed_extensions = (".qgz", ".qgs")
 app = Flask(__name__)
 
 
+def assemble_project_base_path(
+    data_path: str, mandant_name: str, project_name: str
+) -> Path:
+    return Path(data_path, mandant_name, project_name)
+
+
+def assemble_output_file_path(project_base_path: Path, output_format: str) -> Path:
+    return Path(str(project_base_path) + output_format)
+
+
 @app.route("/export", methods=["POST"])
 def api_export():
     logging.getLogger().setLevel(logging.DEBUG)
     data_path = os.environ.get("QSL_DATA_ROOT")
+    if data_path is None:
+        logging.error(
+            "QSL_DATA_ROOT was not defined in the services ENV, we cant run the export."
+        )
+        result = ExportResult(successful=False)
+        return Response(JsonSerializer().render(result), mimetype="text/json")
     body = request.get_json()
     parser_config = ParserConfig(fail_on_unknown_properties=True)
     try:
@@ -27,9 +43,11 @@ def api_export():
     except Exception as e:
         logging.error(e)
         result = ExportResult(successful=False)
-        Response(JsonSerializer().render(result), mimetype="text/json")
+        return Response(JsonSerializer().render(result), mimetype="text/json")
 
-    project_base_path = Path(data_path, parameters.mandant, parameters.project)
+    project_base_path = assemble_project_base_path(
+        data_path, parameters.mandant, parameters.project
+    )
     project_file = None
     for extension in allowed_extensions:
         project_file = Path(str(project_base_path) + extension)
@@ -55,7 +73,9 @@ def api_export():
             check=True,
             capture_output=True,
         )
-        output_file = f"{project_base_path}.{parameters.output_format}"
+        output_file = assemble_output_file_path(
+            project_base_path, parameters.output_format
+        )
         output_file.write_text(process.stdout)
         result = ExportResult(successful=True)
     except subprocess.CalledProcessError as e:

--- a/src/qgis_server_light/exporter/api.py
+++ b/src/qgis_server_light/exporter/api.py
@@ -55,8 +55,7 @@ def api_export():
             check=True,
             capture_output=True,
         )
-        output_format = f".{parameters.output_format}"
-        output_file = project_base_path.with_suffix(output_format)
+        output_file = f"{project_base_path}.{parameters.output_format}"
         output_file.write_text(process.stdout)
         result = ExportResult(successful=True)
     except subprocess.CalledProcessError as e:

--- a/src/qgis_server_light/exporter/api.py
+++ b/src/qgis_server_light/exporter/api.py
@@ -23,7 +23,7 @@ def assemble_project_base_path(
 
 
 def assemble_output_file_path(project_base_path: Path, output_format: str) -> Path:
-    return Path(str(project_base_path) + output_format)
+    return Path(str(project_base_path) + f".{output_format}")
 
 
 @app.route("/export", methods=["POST"])

--- a/tests/unit/exporter/test_api.py
+++ b/tests/unit/exporter/test_api.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+from qgis_server_light.exporter.api import (
+    assemble_output_file_path,
+    assemble_project_base_path,
+)
+
+
+class TestExporter:
+    @pytest.mark.parametrize(
+        "data_path,manadant_name,project_name,expected",
+        [
+            (
+                "/tmp/test",
+                "test_mandant",
+                "test_project",
+                "/tmp/test/test_mandant/test_project",
+            ),
+            (
+                "/tmp/test",
+                "test.mandant",
+                "test.project",
+                "/tmp/test/test.mandant/test.project",
+            ),
+        ],
+    )
+    def test_assemble_project_base_path_behaves(
+        self, data_path, manadant_name, project_name, expected
+    ):
+        assert (
+            str(assemble_project_base_path(data_path, manadant_name, project_name))
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "project_base_path,output_format,expected",
+        [
+            (
+                Path("/tmp/test/test_mandant/test_project"),
+                "json",
+                "/tmp/test/test_mandant/test_project.json",
+            ),
+            (
+                Path("/tmp/test/test.mandant/test.project"),
+                "json",
+                "/tmp/test/test.mandant/test.project.json",
+            ),
+            (
+                Path("/tmp/test/test.mandant/test.project.3.44.10"),
+                "json",
+                "/tmp/test/test.mandant/test.project.3.44.10.json",
+            ),
+        ],
+    )
+    def test_assemble_output_file_path_behaves(
+        self, project_base_path, output_format, expected
+    ):
+        assert (
+            str(assemble_output_file_path(project_base_path, output_format)) == expected
+        )


### PR DESCRIPTION
When project files does contain '.' like `my_project.3.44.0.qgs` then the export creates a `my_project.3.44.json` which leads to inconsistent behaviour.